### PR TITLE
Recursive solver

### DIFF
--- a/lib/gsolver.js
+++ b/lib/gsolver.js
@@ -54,12 +54,19 @@ Solver.prototype.solve = function(bean, context){
 
     var flat = Flattener.flatten(bean);
 
-    var value;
+    var value, result;
     Object.keys(flat).map(function(key){
         value = flat[key];
         if(!this.template.needsInterpolation(value)) return;
-        Keypath.set(out, key, this.template.compile(value, context))
+
+        result = value;
+        while(this.template.needsInterpolation(result)){
+            result = this.template.compile(result, context);
+        }
+        Keypath.set(out, key, result);
+
     }, this);
+
     this.emitNext('solve', out);
 
     return out;

--- a/lib/template.js
+++ b/lib/template.js
@@ -37,7 +37,7 @@ Template.prototype.compile = function (template, context, openTag, closeTag) {
     if (!template) return '';
     if (!context) return template;
 
-    openTag = openTag || this.openTag, closeTag = closeTag || this.closeTag;
+    openTag = (openTag || this.openTag), closeTag = (closeTag || this.closeTag);
 
     template = template.split('.').join('\\.');
     var self = this;
@@ -45,7 +45,7 @@ Template.prototype.compile = function (template, context, openTag, closeTag) {
         var prop = arguments[1];
         prop = prop.replace(/\\/g, '');
         return self.resolvePropertyChain(context, prop, openTag + prop + closeTag);
-    };
+    }
 
     return template.replace(this.rxp, replaceTokens)
                    .replace(/\\\{/g, '{')


### PR DESCRIPTION
This PR maques possible to solve references inside references:

``` js
var config = {
     app: {
        url: 'http://localhost:3030'
    },
    paths: {
        builds: '${app.url}/tmp/rabbithook-builds',
        sources: '${paths.builds}/sources',
        tars: '${paths.builds}/tars',
        logs: '${paths.builds}/logs'
    }
};
config = solver.solve(config);
console.log(config.paths.tars);
```

Before this PR, the value of **onfig.paths.tars**:
- `${app.url}/tmp/rabbithook-builds/tars`

After this PR the result is what we expect:
- `http://localhost:3030/tmp/rabbithook-builds/tars`
